### PR TITLE
fix: clamp subscription total spend

### DIFF
--- a/app/websites/subscription_tracker/context/SubscriptionTrackerContext.tsx
+++ b/app/websites/subscription_tracker/context/SubscriptionTrackerContext.tsx
@@ -284,7 +284,8 @@ export function SubscriptionTrackerProvider({
     }
 
     const timeDiff = nextDate.getTime() - currentDate.getTime();
-    return Math.ceil(timeDiff / (1000 * 3600 * 24));
+    const days = Math.ceil(timeDiff / (1000 * 3600 * 24));
+    return days;
   }
 
   function isSubscriptionDueToday(subscription: Subscription): boolean {
@@ -315,6 +316,10 @@ export function SubscriptionTrackerProvider({
     } else if (subscription.type === "yearly") {
       const years = Math.floor(getYearDifference(startDate, currentDate));
       totalSpend += years * subscription.price;
+    }
+
+    if (totalSpend < 0) {
+      totalSpend = 0;
     }
 
     return totalSpend;


### PR DESCRIPTION
Prevents subscription total spends going below zero and into the negatives. This might happen due to subscriptions being assigned with a future date.